### PR TITLE
Overrode the get_name() function

### DIFF
--- a/BaseballPlayer.cpp
+++ b/BaseballPlayer.cpp
@@ -2,12 +2,17 @@
 #include "BaseballPlayerImpl.h"
 #include <cassert>
 #include <string>
+#include <iostream>
 
 BaseballPlayer::BaseballPlayer(std::string a_name) :
     pImpl_{new BaseballPlayerImpl{std::move(a_name)}}
 {}
 
 BaseballPlayer::~BaseballPlayer() {}
+
+const std::string& BaseballPlayer::get_name() const {
+    return pImpl_->get_name();
+}
 
 bool BaseballPlayer::has_baseball() const {
     return pImpl_->has_baseball();

--- a/BaseballPlayer.cpp
+++ b/BaseballPlayer.cpp
@@ -2,7 +2,6 @@
 #include "BaseballPlayerImpl.h"
 #include <cassert>
 #include <string>
-#include <iostream>
 
 BaseballPlayer::BaseballPlayer(std::string a_name) :
     pImpl_{new BaseballPlayerImpl{std::move(a_name)}}

--- a/BaseballPlayer.h
+++ b/BaseballPlayer.h
@@ -10,6 +10,7 @@ class BaseballPlayer : public Human {
         explicit BaseballPlayer(std::string a_name);
         ~BaseballPlayer();
 
+        const std::string& get_name() const;
         bool has_baseball() const;
         void catch_baseball();
         void throw_baseball(BaseballPlayer &catch_partner);

--- a/BaseballPlayerImpl.cpp
+++ b/BaseballPlayerImpl.cpp
@@ -1,7 +1,6 @@
 #include "BaseballPlayerImpl.h"
 #include <cassert>
 #include <string>
-#include <iostream>
 
 BaseballPlayer::BaseballPlayerImpl::BaseballPlayerImpl(std::string a_name) :
     Human(std::move(a_name))

--- a/BaseballPlayerImpl.cpp
+++ b/BaseballPlayerImpl.cpp
@@ -1,6 +1,7 @@
 #include "BaseballPlayerImpl.h"
 #include <cassert>
 #include <string>
+#include <iostream>
 
 BaseballPlayer::BaseballPlayerImpl::BaseballPlayerImpl(std::string a_name) :
     Human(std::move(a_name))

--- a/main.cpp
+++ b/main.cpp
@@ -61,17 +61,10 @@ void play_catch(BaseballPlayer &player1, BaseballPlayer &player2) {
 
 int main(void) {
 
-
     BaseballPlayer player1("Andrew");
     BaseballPlayer player2("Michael");
 
-    std::cout << "Hey player1 is " << player1.get_name() << std::endl;
-    std::cout << "Hey player1 has baseball? " << player1.has_baseball() << std::endl;
-
-    player1.set_name("Andrew");
-    std::cout << "Hey player1 is " << player1.get_name() << std::endl;
-
-    // play_catch(player1, player2);
+    play_catch(player1, player2);
 
     return 0;
 }


### PR DESCRIPTION
Perhaps the Human Classes version of get_name() was returning this->name which somehow was being confused for the pImpl_ pointer?
I noticed that pImpl_->get_name() was actually returning the correct name and this->get_name() and this->get_name() for both the Human object and
BaseballplayerImpl object was returning the correct name value but this->get_name() for the BaseballPlayer object was not. Perhaps this is not the most ideal
solution but then again pimpl isnt always the most ideal solution either just trying to use this time to learn. I will continue to read in Herb Sutters book
"Exceptional C++: 47 engineering puzzles" He has chapters on pimpl and forward declarations

Let me know if you find a more elegant solution